### PR TITLE
Forwarder needs pledge dns.

### DIFF
--- a/forwarder.c
+++ b/forwarder.c
@@ -65,7 +65,7 @@ forwarder_run(struct privsep *ps, struct privsep_proc *p, void *arg)
 	struct pfresolved	*env = ps->ps_env;
 	int			 fd;
 
-	if (pledge("stdio inet rpath", NULL) == -1)
+	if (pledge("stdio dns inet rpath", NULL) == -1)
 		fatal("%s: pledge", __func__);
 
 	if ((fd = ub_fd(env->sc_ub_ctx)) == -1)


### PR DESCRIPTION
The forwarder process is killed by pledge when libunbound is setting sockopt IPV6_USE_MIN_MTU.
pfresolved CALL  setsockopt(10,41<ipv6>,42,0x566b6b46e28,4) pfresolved PLDG  setsockopt, "inet", errno 1 Operation not permitted pfresolved PSIG  SIGABRT SIG_DFL
Add pledge dns to prevent this.