### PR TITLE
Do not require secret config file.

### DIFF
--- a/parse.y
+++ b/parse.y
@@ -124,7 +124,7 @@ grammar		: /* empty */
 include		: INCLUDE STRING		{
 			struct file	*nfile;
 
-			if ((nfile = pushfile($2, 1)) == NULL) {
+			if ((nfile = pushfile($2, 0)) == NULL) {
 				yyerror("failed to include file %s", $2);
 				free($2);
 				YYERROR;
@@ -628,7 +628,7 @@ parse_config(const char *filename, struct pfresolved *x_env)
 	env = x_env;
 	cur_table = NULL;
 
-	if ((file = pushfile(filename, 1)) == NULL)
+	if ((file = pushfile(filename, 0)) == NULL)
 		return (-1);
 	topfile = file;
 


### PR DESCRIPTION
The permissions of pfresolved.conf are checked by parse.y as it is declared secret.  This was probably copied from iked.  There are no secrets in pfresolved and special pemissions make testing hard. Relax the requirement and skip the check.