### PR TITLE
Check if hostname len is negative before casting to size_t.

### DIFF
--- a/pfresolved.c
+++ b/pfresolved.c
@@ -527,7 +527,7 @@ parent_get_resolve_result_data(struct pfresolved *env, struct imsg *imsg,
 	ptr += sizeof(hostname_len);
 	len -= sizeof(hostname_len);
 
-	if (len < (size_t)hostname_len)
+	if (hostname_len < 0 || len < (size_t)hostname_len)
 		fatalx("%s: imsg length too small", __func__);
 
 	memcpy(search_key.pfh_hostname, ptr, hostname_len);


### PR DESCRIPTION
After reading the C99 standard, I think the current code is correct. But explicitly checking the invalid negative length case during input validation is much easier than understanding integer conversions in C.