### PR TITLE
Start nsd to provide answers for pfresolved.

### DIFF
--- a/regress/Makefile
+++ b/regress/Makefile
@@ -9,7 +9,12 @@ PFRESOLVED ?=		${.CURDIR}/../pfresolved
 PERLS =			Proc.pm Pfresolved.pm funcs.pl pfresolved.pl
 ARGS !=			cd ${.CURDIR} && ls args-*.pl
 REGRESS_TARGETS =       ${ARGS:S/^/run-/}
-CLEANFILES =		*.log *.conf ktrace.out stamp-* *.pid *.ktrace
+CLEANFILES =		*.log *.conf ktrace.out stamp-* *.pid *.ktrace *.zone
+
+REGRESS_SETUP_ONCE =	chmod-obj
+chmod-obj:
+	# nsd user needs read permission for zone file
+	-chmod o+rx ${.OBJDIR}
 
 # Set variables so that make runs with and without obj directory.
 # Only do that if necessary to keep visible output short.

--- a/regress/Pfctl.pm
+++ b/regress/Pfctl.pm
@@ -29,16 +29,20 @@ sub new {
 	$args{up} ||= "Table";
 
 	my $self = Proc::new($class, %args);
+
 	return $self;
 }
 
 sub child {
 	my $self = shift;
 	my $timeout = $self->{timeout} || 5;
-	my $updates = $self->{updates};
+	my $updated = $self->{updated};
 	my $pfresolved = $self->{pfresolved};
 
-	my $table = "updated addresses for pf table";
+	# make it possible to match on /added: 2,/ by passing array
+	my ($updates, $added) = ($updated->[0], $updated->[1]);
+
+	my $table = qr/updated addresses for pf table .*: added: $added,/;
 	my $tomsg = $timeout ? " after $timeout seconds" : "";
 	my $upmsg = $updates ? " for $updates times" : "";
 	$pfresolved->loggrep($table, $timeout, $updates)
@@ -53,7 +57,7 @@ sub func {
 	my $self = shift;
 	my @sudo = $ENV{SUDO} ? $ENV{SUDO} : ();
 
-	my @cmd = (@sudo, qw(pfctl -t regress-pfresolved -T show));
+	my @cmd = (@sudo, qw(/sbin/pfctl -t regress-pfresolved -T show));
 	system(@cmd)
 	    and die die ref($self), " command '@cmd' failed: $?";
 }

--- a/regress/args-ip.pl
+++ b/regress/args-ip.pl
@@ -11,6 +11,7 @@ our %args = (
 	address_list => [qw(192.0.2.1 2001:DB8::1)],  # documentation IPs
     },
     pfctl => {
+	updated => [1, 2],
 	loggrep => {
 	    qr/^   192.0.2.1$/ => 1,
 	    qr/^   2001:db8::1$/ => 1,

--- a/regress/args-localhost.pl
+++ b/regress/args-localhost.pl
@@ -16,7 +16,7 @@ our %args = (
 	},
     },
     pfctl => {
-	updates => 3,
+	updated => [1, 1],
 	loggrep => {
 	    qr/^   127.0.0.1$/ => 1,
 	    qr/^   ::1$/ => 1,

--- a/regress/args-nsd.pl
+++ b/regress/args-nsd.pl
@@ -1,0 +1,40 @@
+# Create zone file with A and AAAA records in zone regress.
+# Start nsd with zone file listening on 127.0.0.1.
+# Write hosts of regress zone into pfresolved config.
+# Start pfresolved with nsd as resolver.
+# Wait until pfresolved creates table regress-pfresolved.
+# Read IP addresses from pf table with pfctl.
+# Check that pfresolved added IPv4 and IPv6 addresses.
+# Check that pf table contains all IPv4 and IPv6 addresses.
+
+use strict;
+use warnings;
+
+our %args = (
+    nsd => {
+	record_list => [
+	    "foo	IN	A	192.0.2.1",
+	    "bar	IN	AAAA	2001:DB8::1",
+	    "foobar	IN	A	192.0.2.2",
+	    "foobar	IN	AAAA	2001:DB8::2",
+	],
+    },
+    pfresolved => {
+	address_list => [ map { "$_.regress." } qw(foo bar foobar) ],
+	loggrep => {
+	    qr{added: 192.0.2.1/32,} => 1,
+	    qr{added: 2001:db8::1/128,} => 1,
+	    qr{added: 192.0.2.2/32,} => 1,
+	    qr{added: 2001:db8::2/128,} => 1,
+	},
+    },
+    pfctl => {
+	updated => [4, 1],
+	loggrep => {
+	    qr/^   192.0.2.[12]$/ => 2,
+	    qr/^   2001:db8::[12]$/ => 2,
+	},
+    },
+);
+
+1;

--- a/regress/funcs.pl
+++ b/regress/funcs.pl
@@ -16,6 +16,28 @@
 
 use strict;
 use warnings;
+use IO::Socket::IP;
+
+sub find_ports {
+	my %args = @_;
+	my $num    = delete $args{num}    // 1;
+	my $domain = delete $args{domain} // AF_INET;
+	my $addr   = delete $args{addr}   // "127.0.0.1";
+	my $proto  = delete $args{proto}  // "udp";
+	$proto = "tcp" if $proto eq "tls";
+
+	my @sockets = (1..$num);
+	foreach my $s (@sockets) {
+		$s = IO::Socket::IP->new(
+		    Domain    => $domain,
+		    LocalAddr => $addr,
+		    Proto     => $proto,
+		) or die "find_ports: create and bind socket failed: $!";
+	}
+	my @ports = map { $_->sockport() } @sockets;
+
+	return wantarray ? @ports : $ports[0];
+}
 
 sub check_logs {
 	my ($n, $d, $s, %args) = @_;
@@ -29,7 +51,7 @@ sub check_loggrep {
 	my ($n, $d, $s, %args) = @_;
 
 	my %name2proc = (nsd => $n, pfresolved => $d, pfctl => $s);
-	foreach my $name (qw(pfresolved pfctl)) {
+	foreach my $name (qw(nsd pfresolved pfctl)) {
 		my $p = $name2proc{$name} or next;
 		my $pattern = $args{$name}{loggrep} or next;
 		$pattern = [ $pattern ] unless ref($pattern) eq 'ARRAY';


### PR DESCRIPTION
Create zone file with A and AAAA records in zone regress. Start nsd with zone file listening on 127.0.0.1.
Write hosts of regress zone into pfresolved config. Start pfresolved with nsd as resolver.
Wait until pfresolved creates table regress-pfresolved. Read IP addresses from pf table with pfctl.
Check that pfresolved added IPv4 and IPv6 addresses. Check that pf table contains all IPv4 and IPv6 addresses.