### PR TITLE
Test query to nsd over IPv6 socket.

### DIFF
--- a/regress/Nsd.pm
+++ b/regress/Nsd.pm
@@ -21,6 +21,7 @@ package Nsd;
 use parent 'Proc';
 use Carp;
 use File::Basename;
+use Socket;
 use Sys::Hostname;
 
 sub new {
@@ -44,6 +45,14 @@ sub new {
 	print $fh "# test $test\n";
 	print $fh "server:\n";
 	print $fh "	chroot: \"\"\n";
+	if ($self->{listen}{domain} && $self->{listen}{domain} == AF_INET) {
+		print $fh "	do-ip4: yes\n";
+		print $fh "	do-ip6: no\n";
+	}
+	if ($self->{listen}{domain} && $self->{listen}{domain} == AF_INET6) {
+		print $fh "	do-ip4: no\n";
+		print $fh "	do-ip6: yes\n";
+	}
 	print $fh "	ip-address: $self->{addr}\n";
 	print $fh "	pidfile: \"\"\n";
 	print $fh "	port: $self->{port}\n";


### PR DESCRIPTION
Create zone file with A and AAAA records in zone regress. Start nsd with zone file listening on ::1.
Write hosts of regress zone into pfresolved config. Start pfresolved with nsd as resolver.
Wait until pfresolved creates table regress-pfresolved. Read IP addresses from pf table with pfctl.
Check that pfresolved added IPv4 and IPv6 addresses. Check that pf table contains all IPv4 and IPv6 addresses. Check that IPv6 ::1 socket was used.