### PR TITLE
Only include system certs without cert bundle

### DIFF
--- a/forwarder.c
+++ b/forwarder.c
@@ -235,15 +235,18 @@ forwarder_ub_ctx_init(struct pfresolved *env)
 			fatalx("%s: ub_ctx_set_tls failed: %s", __func__,
 			    ub_strerror(res));
 
-		/* include root certs from /etc/ssl/cert.pem */
-		if ((res = ub_ctx_set_option(ctx, "tls-system-cert:", "yes")) != 0)
-			fatalx("%s: ub_ctx_set_option tls-system-cert failed: %s",
-			    __func__, ub_strerror(res));
-
-		if (env->sc_cert_bundle && (res = ub_ctx_set_option(ctx,
-		    "tls-cert-bundle:", env->sc_cert_bundle)) != 0)
-			fatalx("%s: ub_ctx_set_option tls-cert-bundle failed: %s",
-			    __func__, ub_strerror(res));
+		if (env->sc_cert_bundle) {
+			if ((res = ub_ctx_set_option(ctx, "tls-cert-bundle:",
+			    env->sc_cert_bundle)) != 0)
+				fatalx("%s: ub_ctx_set_option tls-cert-bundle "
+				    "failed: %s", __func__, ub_strerror(res));
+		} else {
+			/* include root certs from /etc/ssl/cert.pem */
+			if ((res = ub_ctx_set_option(ctx, "tls-system-cert:",
+			    "yes")) != 0)
+				fatalx("%s: ub_ctx_set_option tls-system-cert "
+				    "failed: %s", __func__, ub_strerror(res));
+		}
 	}
 
 	if (env->sc_dnssec_level > DNSSEC_NONE) {

--- a/pfresolved.8
+++ b/pfresolved.8
@@ -122,8 +122,7 @@ Unsigned query results will be discarded.
 .It Fl T
 Enable DNS-over-TLS.
 The system certificates will be automatically included and used for
-authentication.
-An additional certificate bundle can be specified using
+authentication unless a certificate bundle is specified using
 .Fl C .
 .It Fl v
 Produce more verbose output.


### PR DESCRIPTION
Users should be able to fully control which certificates are used for DNS over TLS. Therefore we only include the default system certificates if no certificate bundle has been specified with the -C option.