### PR TITLE
Test query to nsd over TLS socket.

### DIFF
--- a/regress/Makefile
+++ b/regress/Makefile
@@ -36,6 +36,26 @@ run-$a: $a
 	    perl ${PERLINC} ${PERLPATH}pfresolved.pl ${PERLPATH}$a
 .endfor
 
+# create certificates for TLS
+
+CLEANFILES +=	*.crt *.key *.req *.srl
+
+ca.crt:
+	openssl req -batch -new \
+	    -subj /L=OpenBSD/O=pfresolved-regress/OU=ca/CN=root/ \
+	    -nodes -newkey rsa -keyout ${@:R}.key -x509 -out $@
+
+server.req:
+	openssl req -batch -new \
+	    -subj /L=OpenBSD/O=pfresolved-regress/OU=${@:R}/CN=localhost/ \
+	    -nodes -newkey rsa -keyout ${@:R}.key -out $@
+
+server.crt: ca.crt ${@:R}.req
+	openssl x509 -CAcreateserial -CAkey ca.key -CA ca.crt -req \
+	    -in ${@:R}.req -out $@
+
+${REGRESS_TARGETS:M*tls*}: server.crt
+
 # make perl syntax check for all args files
 
 .PHONY: syntax

--- a/regress/Nsd.pm
+++ b/regress/Nsd.pm
@@ -56,6 +56,11 @@ sub new {
 	print $fh "	ip-address: $self->{addr}\n";
 	print $fh "	pidfile: \"\"\n";
 	print $fh "	port: $self->{port}\n";
+	if ($self->{tls}) {
+		print $fh "	tls-port: $self->{port}\n";
+		print $fh "	tls-service-key: \"server.key\"\n";
+		print $fh "	tls-service-pem: \"server.crt\"\n";
+	}
 	print $fh "	verbosity: 3\n";
 	print $fh "	zonesdir: .\n";
 	print $fh "zone:\n";

--- a/regress/Pfresolved.pm
+++ b/regress/Pfresolved.pm
@@ -72,9 +72,14 @@ sub child {
 	my $resolver;
 	$resolver = $self->{addr} if $self->{addr};
 	$resolver .= '@'.$self->{port} if $self->{port};
+	$resolver .= '#localhost' if $self->{tls};
 	my @cmd = (@sudo, @ktrace, $self->{execfile}, "-dvvv",
 	    "-f", $self->{conffile});
 	push @cmd, "-r", $resolver if $resolver;
+	if ($self->{tls}) {
+		push @cmd, "-C", "ca.crt" if $self->{tls};
+		push @cmd, "-T" if $self->{tls};
+	}
 	print STDERR "execute: @cmd\n";
 	exec @cmd;
 	die ref($self), " exec '@cmd' failed: $!";

--- a/regress/args-tls.pl
+++ b/regress/args-tls.pl
@@ -1,0 +1,47 @@
+# Create zone file with A and AAAA records in zone regress.
+# Start nsd with zone file listening on 127.0.0.1.
+# Write hosts of regress zone into pfresolved config.
+# Start pfresolved with nsd as resolver.
+# Wait until pfresolved creates table regress-pfresolved.
+# Read IP addresses from pf table with pfctl.
+# Check that pfresolved added IPv4 and IPv6 addresses.
+# Check that pf table contains all IPv4 and IPv6 addresses.
+# Check that IPv4 127.0.0.1 #localhost socket was used.
+
+use strict;
+use warnings;
+use Socket;
+
+our %args = (
+    nsd => {
+	listen => { proto => "tls" },
+	record_list => [
+	    "foo	IN	A	192.0.2.1",
+	    "bar	IN	AAAA	2001:DB8::1",
+	    "foobar	IN	A	192.0.2.2",
+	    "foobar	IN	AAAA	2001:DB8::2",
+	],
+	loggrep => {
+	    qr/listen on ip-address 127.0.0.1\@\d+ \(tcp\)/ => 1,
+	},
+    },
+    pfresolved => {
+	address_list => [ map { "$_.regress." } qw(foo bar foobar) ],
+	loggrep => {
+	    qr/-r 127.0.0.1\@\d+#localhost/ => 1,
+	    qr{added: 192.0.2.1/32,} => 1,
+	    qr{added: 2001:db8::1/128,} => 1,
+	    qr{added: 192.0.2.2/32,} => 1,
+	    qr{added: 2001:db8::2/128,} => 1,
+	},
+    },
+    pfctl => {
+	updated => [4, 1],
+	loggrep => {
+	    qr/^   192.0.2.[12]$/ => 2,
+	    qr/^   2001:db8::[12]$/ => 2,
+	},
+    },
+);
+
+1;

--- a/regress/pfresolved.pl
+++ b/regress/pfresolved.pl
@@ -39,12 +39,14 @@ if (@ARGV and -f $ARGV[-1]) {
 my $n = Nsd->new(
     addr		=> $args{nsd}{listen}{addr} //= "127.0.0.1",
     port		=> scalar find_ports(%{$args{nsd}{listen}}),
+    tls			=> ($args{nsd}{listen}{proto} // "") eq "tls",
     %{$args{nsd}},
     testfile		=> $testfile,
 ) if $args{nsd};
 my $d = Pfresolved->new(
     addr		=> $n && $n->{addr},
     port		=> $n && $n->{port},
+    tls			=> $n && $n->{tls},
     %{$args{pfresolved}},
     testfile		=> $testfile,
 );


### PR DESCRIPTION
Create zone file with A and AAAA records in zone regress. Start nsd with zone file listening on ::1.
Write hosts of regress zone into pfresolved config. Start pfresolved with nsd as resolver.
Wait until pfresolved creates table regress-pfresolved. Read IP addresses from pf table with pfctl.
Check that pfresolved added IPv4 and IPv6 addresses. Check that pf table contains all IPv4 and IPv6 addresses. Check that IPv6 ::1 socket was used.