### PR TITLE
Test TLS connection with bad CA must fail.

### DIFF
--- a/regress/Makefile
+++ b/regress/Makefile
@@ -40,7 +40,7 @@ run-$a: $a
 
 CLEANFILES +=	*.crt *.key *.req *.srl
 
-ca.crt:
+ca.crt badca.crt:
 	openssl req -batch -new \
 	    -subj /L=OpenBSD/O=pfresolved-regress/OU=ca/CN=root/ \
 	    -nodes -newkey rsa -keyout ${@:R}.key -x509 -out $@
@@ -55,6 +55,7 @@ server.crt: ca.crt ${@:R}.req
 	    -in ${@:R}.req -out $@
 
 ${REGRESS_TARGETS:M*tls*}: server.crt
+${REGRESS_TARGETS:M*badca*}: badca.crt
 
 # make perl syntax check for all args files
 

--- a/regress/Pfresolved.pm
+++ b/regress/Pfresolved.pm
@@ -77,7 +77,8 @@ sub child {
 	    "-f", $self->{conffile});
 	push @cmd, "-r", $resolver if $resolver;
 	if ($self->{tls}) {
-		push @cmd, "-C", "ca.crt" if $self->{tls};
+		my $ca = $self->{ca} || "ca.crt";
+		push @cmd, "-C", $ca if $self->{tls};
 		push @cmd, "-T" if $self->{tls};
 	}
 	print STDERR "execute: @cmd\n";

--- a/regress/args-tls-badca.pl
+++ b/regress/args-tls-badca.pl
@@ -1,0 +1,54 @@
+# Create zone file with A and AAAA records in zone regress.
+# Start nsd with zone file listening on 127.0.0.1.
+# Write hosts of regress zone into pfresolved config.
+# Start pfresolved with nsd as resolver.
+# Pfresolved is provided with wrong CA to verify server cert.
+# Wait until pfresolved reports lookup failure.
+# Check that pfresolved added no addresses.
+# Check that pfresolved reports "certificate verify failed".
+
+use strict;
+use warnings;
+use Socket;
+
+our %args = (
+    nsd => {
+	listen => { proto => "tls" },
+	record_list => [
+	    "foo	IN	A	192.0.2.1",
+	    "bar	IN	AAAA	2001:DB8::1",
+	    "foobar	IN	A	192.0.2.2",
+	    "foobar	IN	AAAA	2001:DB8::2",
+	],
+	loggrep => {
+	    qr/listen on ip-address 127.0.0.1\@\d+ \(tcp\)/ => 1,
+	},
+    },
+    pfresolved => {
+	address_list => [ map { "$_.regress." } qw(foo bar foobar) ],
+	ca => "badca.crt",
+	loggrep => {
+	    qr/-C badca.crt/ => 1,
+	    qr/error: and additionally crypto error:.*/.
+		qr/certificate verify failed/ => 1,
+	    qr{added: 192.0.2.1/32,} => 0,
+	    qr{added: 2001:db8::1/128,} => 0,
+	    qr{added: 192.0.2.2/32,} => 0,
+	    qr{added: 2001:db8::2/128,} => 0,
+	},
+    },
+    pfctl => {
+	updated => [1, 0],
+	func => sub {
+	    my $self = shift;
+	    my $pfresolved = $self->{pfresolved};
+	    my $failed = qr/query for .* failed/;
+	    my $timeout = 5;
+	    $pfresolved->loggrep($failed, $timeout)
+		or die ref($self), " no '$failed' in $pfresolved->{logfile}",
+		    " after $timeout seconds";
+	},
+    },
+);
+
+1;


### PR DESCRIPTION
Create zone file with A and AAAA records in zone regress. Start nsd with zone file listening on 127.0.0.1.
Write hosts of regress zone into pfresolved config. Start pfresolved with nsd as resolver.
Pfresolved is provided with wrong CA to verify server cert. Wait until pfresolved reports lookup failure.
Check that pfresolved added no addresses.
Check that pfresolved reports "certificate verify failed".