### PR TITLE
Test fetch from DNSSEC signed zone.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             whoami
             env | sort
             echo == depend ==
-            sudo pkg_add libunbound
+            sudo pkg_add libunbound ldns-utils
             sudo useradd -m _pfresolved
             echo == build ==
             make all

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -57,6 +57,23 @@ server.crt: ca.crt ${@:R}.req
 ${REGRESS_TARGETS:M*tls*}: server.crt
 ${REGRESS_TARGETS:M*badca*}: badca.crt
 
+# create zone and key signing keys for DNSSEC
+
+CLEANFILES +=	*.key *.private *.ds .key .private .ds
+
+zsk.key:
+	ldns-keygen -a ED25519 -sf regress
+	mv .key zsk.key
+	mv .private zsk.private
+
+ksk.key:
+	ldns-keygen -a ED25519 -k -sf regress
+	mv .key ksk.key
+	mv .private ksk.private
+	mv .ds ksk.ds
+
+${REGRESS_TARGETS:M*dnssec*}: zsk.key ksk.key
+
 # make perl syntax check for all args files
 
 .PHONY: syntax

--- a/regress/Pfresolved.pm
+++ b/regress/Pfresolved.pm
@@ -78,6 +78,10 @@ sub child {
 	    "-f", $self->{conffile});
 	push @cmd, "-r", $resolver if $resolver;
 	push @cmd, "-m", $self->{min_ttl} if $self->{min_ttl};
+	if ($self->{dnssec_level}) {
+		push @cmd, "-A", "ksk.ds";
+		push @cmd, "-S", $self->{dnssec_level};
+	}
 	if ($self->{tls}) {
 		my $ca = $self->{ca} || "ca.crt";
 		push @cmd, "-C", $ca if $self->{tls};

--- a/regress/args-dnssec.pl
+++ b/regress/args-dnssec.pl
@@ -1,0 +1,44 @@
+# Create signed zone file with A and AAAA records in zone regress.
+# Start nsd with signed zone file listening on 127.0.0.1.
+# Write hosts of regress zone into pfresolved config.
+# Start pfresolved with nsd as resolver and dnssec level 3.
+# Wait until pfresolved creates table regress-pfresolved.
+# Read IP addresses from pf table with pfctl.
+# Check that pfresolved added IPv4 and IPv6 addresses.
+# Check that pfresolved logged secure when receiving dns.
+
+use strict;
+use warnings;
+
+our %args = (
+    nsd => {
+	dnssec => 1,
+	record_list => [
+	    "foo	IN	A	192.0.2.1",
+	    "bar	IN	AAAA	2001:DB8::1",
+	    "foobar	IN	A	192.0.2.2",
+	    "foobar	IN	AAAA	2001:DB8::2",
+	],
+    },
+    pfresolved => {
+	dnssec_level => 3,
+	address_list => [ map { "$_.regress." } qw(foo bar foobar) ],
+	loggrep => {
+	    qr/-S 3/ => 1,
+	    qr/result for .* secure: 1,/ => 6,
+	    qr{added: 192.0.2.1/32,} => 1,
+	    qr{added: 2001:db8::1/128,} => 1,
+	    qr{added: 192.0.2.2/32,} => 1,
+	    qr{added: 2001:db8::2/128,} => 1,
+	},
+    },
+    pfctl => {
+	updated => [4, 1],
+	loggrep => {
+	    qr/^   192.0.2.[12]$/ => 2,
+	    qr/^   2001:db8::[12]$/ => 2,
+	},
+    },
+);
+
+1;


### PR DESCRIPTION
Create signed zone file with A and AAAA records in zone regress. Start nsd with signed zone file listening on 127.0.0.1. Write hosts of regress zone into pfresolved config. Start pfresolved with nsd as resolver and dnssec level 3. Wait until pfresolved creates table regress-pfresolved. Read IP addresses from pf table with pfctl.
Check that pfresolved added IPv4 and IPv6 addresses. Chack that pfresolved logged secure when receiving dns.