### PR TITLE
Test DNSSEC with bad trust anchor.

### DIFF
--- a/regress/Makefile
+++ b/regress/Makefile
@@ -55,24 +55,27 @@ server.crt: ca.crt ${@:R}.req
 	    -in ${@:R}.req -out $@
 
 ${REGRESS_TARGETS:M*tls*}: server.crt
-${REGRESS_TARGETS:M*badca*}: badca.crt
+${REGRESS_TARGETS:M*tls-bad*}: badca.crt
 
 # create zone and key signing keys for DNSSEC
 
 CLEANFILES +=	*.key *.private *.ds .key .private .ds
 
 zsk.key:
+	rm -f ${@:R}.*
 	ldns-keygen -a ED25519 -sf regress
-	mv .key zsk.key
-	mv .private zsk.private
+	mv .key ${@:R}.key
+	mv .private ${@:R}.private
 
-ksk.key:
+ksk.key badksk.key:
+	rm -f ${@:R}.*
 	ldns-keygen -a ED25519 -k -sf regress
-	mv .key ksk.key
-	mv .private ksk.private
-	mv .ds ksk.ds
+	mv .key ${@:R}.key
+	mv .private ${@:R}.private
+	mv .ds ${@:R}.ds
 
 ${REGRESS_TARGETS:M*dnssec*}: zsk.key ksk.key
+${REGRESS_TARGETS:M*dnssec-bad*}: badksk.key
 
 # make perl syntax check for all args files
 

--- a/regress/Pfresolved.pm
+++ b/regress/Pfresolved.pm
@@ -78,8 +78,11 @@ sub child {
 	    "-f", $self->{conffile});
 	push @cmd, "-r", $resolver if $resolver;
 	push @cmd, "-m", $self->{min_ttl} if $self->{min_ttl};
+	push @cmd, "-A", $self->{trust_anchor_file}
+	    if $self->{trust_anchor_file};
 	if ($self->{dnssec_level}) {
-		push @cmd, "-A", "ksk.ds";
+		push @cmd, "-A", "ksk.ds"
+		    unless $self->{trust_anchor_file};
 		push @cmd, "-S", $self->{dnssec_level};
 	}
 	if ($self->{tls}) {

--- a/regress/args-dnssec-badds.pl
+++ b/regress/args-dnssec-badds.pl
@@ -1,0 +1,55 @@
+# Test DNSSEC with bad trust anchor.
+
+# Create signed zone file with A and AAAA records in zone regress.
+# Start nsd with unsigned zone file listening on 127.0.0.1.
+# Write hosts of regress zone into pfresolved config.
+# Start pfresolved with nsd as resolver with bad trust anchor.
+# Wait until pfresolved is starting new resolve request after failure.
+# Read IP addresses from pf table with pfctl.
+# Check that pf table contains neither IPv4 nor IPv6 addresses.
+# Check that pfresolved logged "validation failure" and "no keys have a DS".
+
+use strict;
+use warnings;
+
+our %args = (
+    nsd => {
+	dnssec => 1,
+	record_list => [
+	    "foo	IN	A	192.0.2.1",
+	    "bar	IN	AAAA	2001:DB8::1",
+	    "foobar	IN	A	192.0.2.2",
+	    "foobar	IN	AAAA	2001:DB8::2",
+	],
+    },
+    pfresolved => {
+	dnssec_level => 2,
+	trust_anchor_file => "badksk.ds",
+	address_list => [ map { "$_.regress." } qw(foo bar foobar) ],
+	loggrep => {
+	    qr/-A badksk.ds/ => 1,
+	    qr/result for .*: validation failure .* no keys have a DS/ => 6,
+	},
+    },
+    pfctl => {
+	updated => [1, 0],
+	func => sub {
+		my $self = shift;
+		my $pfresolved = $self->{pfresolved};
+
+		my $restart = qr/starting new resolve request/;
+		my $timeout = 5;
+		$pfresolved->loggrep($restart, $timeout) or die ref($self),
+		    " no '$restart' in $pfresolved->{logfile}",
+		    " after $timeout seconds";
+
+		$self->show();
+	    },
+	loggrep => {
+	    qr/^   192.0.2.[12]$/ => 0,
+	    qr/^   2001:db8::[12]$/ => 0,
+	},
+    },
+);
+
+1;


### PR DESCRIPTION
Create signed zone file with A and AAAA records in zone regress. Start nsd with unsigned zone file listening on 127.0.0.1. Write hosts of regress zone into pfresolved config. Start pfresolved with nsd as resolver with bad trust anchor. Wait until pfresolved refuses to resolve unsigned entries. Read IP addresses from pf table with pfctl.
Check that pf table contains neither IPv4 nor IPv6 addresses. Check that pfresolved logged "validation failure" and "no DNSKEY rrset".