### PR TITLE
Fix race in loading nsd zone file in ttl test.

### DIFF
--- a/regress/Nsd.pm
+++ b/regress/Nsd.pm
@@ -98,6 +98,7 @@ sub zone {
 	foreach my $r (@{$self->{record_list} || []}) {
 		print $fz "$r\n";
 	}
+	close($fz);
 
 	if ($self->{dnssec}) {
 		my @cmd = qw(/usr/local/bin/ldns-signzone -b nsd.zone zsk ksk);


### PR DESCRIPTION
In github CI make run-args-ttl.pl shows this error: nsd[58565]: warning: SIGHUP received, reloading... nsd[75456]: error: nsd.zone:1: zone configured as 'regress.' has no SOA record.

After writing the new zone file, there is no flush.  So zone signing or nsd reload may miss the new file content.  Close zone file before other process uses it.