### PR TITLE
Test DNSSEC key signing key as trust anchor.

### DIFF
--- a/regress/args-dnssec-ksk.pl
+++ b/regress/args-dnssec-ksk.pl
@@ -1,9 +1,9 @@
-# Test DNSSEC with delegation signer as trust anchor.
+# Test DNSSEC with signing key as trust anchor.
 
 # Create signed zone file with A and AAAA records in zone regress.
 # Start nsd with signed zone file listening on 127.0.0.1.
 # Write hosts of regress zone into pfresolved config.
-# Start pfresolved with nsd as resolver, dnssec level 3, and ds trust anchor.
+# Start pfresolved with nsd as resolver, dnssec level 3, and ksk trust anchor.
 # Wait until pfresolved creates table regress-pfresolved.
 # Read IP addresses from pf table with pfctl.
 # Check that pfresolved added IPv4 and IPv6 addresses.
@@ -24,10 +24,10 @@ our %args = (
     },
     pfresolved => {
 	dnssec_level => 3,
+	trust_anchor_file => "ksk.key",
 	address_list => [ map { "$_.regress." } qw(foo bar foobar) ],
 	loggrep => {
-	    qr/-S 3/ => 1,
-	    qr/-A ksk.ds/ => 1,
+	    qr/-A ksk.key/ => 1,
 	    qr/result for .* secure: 1,/ => 6,
 	    qr{added: 192.0.2.1/32,} => 1,
 	    qr{added: 2001:db8::1/128,} => 1,


### PR DESCRIPTION
Create signed zone file with A and AAAA records in zone regress. Start nsd with signed zone file listening on 127.0.0.1. Write hosts of regress zone into pfresolved config. Start pfresolved with nsd as resolver, dnssec level 3, and ksk trust anchor. Wait until pfresolved creates table regress-pfresolved. Read IP addresses from pf table with pfctl.
Check that pfresolved added IPv4 and IPv6 addresses. Check that pfresolved logged secure when receiving dns.