### PR TITLE
Add make dist to build a release.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,0 +1,4 @@
+Revision history for pfresolved pf table DNS update daemon
+
+1.00
+  * Initial public release.

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SRCS=		pfresolved.c
 SRCS+=		forwarder.c log.c pftable.c proc.c timer.c util.c
 SRCS+=		parse.y
 MAN=		pfresolved.8 pfresolved.conf.5
+BINDIR?=	/usr/local/bin
+MANDIR?=	/usr/local/man/man
 
 LDADD+=		-lutil -levent -lexecinfo -lunbound
 DPADD+=		${LIBUTIL} ${LIBEVENT} ${LIBEXECINFO} ${LIBUNBOUND}
@@ -13,10 +15,32 @@ CFLAGS+=	-Wstrict-prototypes -Wmissing-prototypes
 CFLAGS+=	-Wmissing-declarations
 CFLAGS+=	-Wshadow -Wpointer-arith -Wcast-qual
 CFLAGS+=	-Wsign-compare
-CFLAGS+=	-Werror
 
 LDFLAGS+=	-L/usr/local/lib
 
+VERSION=	1.00
+CLEANFILES=	pfresolved-${VERSION}.tar.gz*
+REGRESSFILES!=	make -C ${.CURDIR}/regress -V PERLS -V ARGS
+
+.PHONY: dist pfresolved-${VERSION}.tar.gz
+dist: pfresolved-${VERSION}.tar.gz
+	gpg --armor --detach-sign pfresolved-${VERSION}.tar.gz
+	@echo ${.OBJDIR}/pfresolved-${VERSION}.tar.gz
+
+pfresolved-${VERSION}.tar.gz:
+	rm -rf pfresolved-${VERSION}
+	mkdir pfresolved-${VERSION}
+.for f in README LICENSE Changes Makefile ${SRCS} pfresolved.h ${MAN}
+	cp ${.CURDIR}/$f pfresolved-${VERSION}/
+.endfor
+	mkdir pfresolved-${VERSION}/regress
+.for f in Makefile ${REGRESSFILES}
+	cp ${.CURDIR}/regress/$f pfresolved-${VERSION}/regress/
+.endfor
+	tar -czvf $@ pfresolved-${VERSION}
+	rm -rf pfresolved-${VERSION}
+
+.PHONY: test
 test: pfresolved
 	PFRESOLVED=${.OBJDIR}/pfresolved ${MAKE} -C ${.CURDIR}/regress
 

--- a/regress/Makefile
+++ b/regress/Makefile
@@ -6,7 +6,8 @@ PFRESOLVED ?=		${.CURDIR}/../${.OBJDIR:T}/pfresolved
 PFRESOLVED ?=		${.CURDIR}/../pfresolved
 .endif
 
-PERLS =			Proc.pm Pfresolved.pm funcs.pl pfresolved.pl
+PERLS =			Nsd.pm Pfctl.pm Pfresolved.pm Proc.pm \
+			funcs.pl pfresolved.pl
 ARGS !=			cd ${.CURDIR} && ls args-*.pl
 REGRESS_TARGETS =       ${ARGS:S/^/run-/}
 CLEANFILES =		*.log *.conf ktrace.out stamp-* *.pid *.ktrace *.zone


### PR DESCRIPTION
Make dist builds a release tar.gz with all source and test files. It uses local gpg key to sign it.  Start with version 1.00 and an empty change log.  Install binary and man page to /usr/local/ . Compiler flag -Werror is a bad idea for portable code.