### PR TITLE
Fail regress in github CI early.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,6 @@ jobs:
             echo == build ==
             make all
             echo == test ==
-            REGRESS_FAIL_EARLY=no SUDO=sudo make test 2>&1 | tee make.log
+            REGRESS_FAIL_EARLY=yes SUDO=sudo make test 2>&1 | tee make.log
             tail -n1000 regress/*.log
             ! grep -B1 FAILED make.log


### PR DESCRIPTION
Fail immediately after a broken test.  Then the printed log files contain the reason of failure and not the last successful test. This may help to debug some races in the tests.