### PR TITLE
Increase pfctl timeout from 5 to 15 seconds.

### DIFF
--- a/regress/Pfctl.pm
+++ b/regress/Pfctl.pm
@@ -35,7 +35,7 @@ sub new {
 
 sub child {
 	my $self = shift;
-	my $timeout = $self->{timeout} || 5;
+	my $timeout = $self->{timeout} || 15;
 	my $updated = $self->{updated};
 	my $pfresolved = $self->{pfresolved};
 

--- a/regress/args-dnssec-badds.pl
+++ b/regress/args-dnssec-badds.pl
@@ -38,7 +38,7 @@ our %args = (
 		my $pfresolved = $self->{pfresolved};
 
 		my $restart = qr/starting new resolve request/;
-		my $timeout = 5;
+		my $timeout = 15;
 		$pfresolved->loggrep($restart, $timeout) or die ref($self),
 		    " no '$restart' in $pfresolved->{logfile}",
 		    " after $timeout seconds";

--- a/regress/args-dnssec-nokey.pl
+++ b/regress/args-dnssec-nokey.pl
@@ -37,7 +37,7 @@ our %args = (
 		my $pfresolved = $self->{pfresolved};
 
 		my $restart = qr/starting new resolve request/;
-		my $timeout = 5;
+		my $timeout = 15;
 		$pfresolved->loggrep($restart, $timeout) or die ref($self),
 		    " no '$restart' in $pfresolved->{logfile}",
 		    " after $timeout seconds";

--- a/regress/args-dnssec-nosig.pl
+++ b/regress/args-dnssec-nosig.pl
@@ -38,7 +38,7 @@ our %args = (
 		my $pfresolved = $self->{pfresolved};
 
 		my $restart = qr/starting new resolve request/;
-		my $timeout = 5;
+		my $timeout = 15;
 		$pfresolved->loggrep($restart, $timeout) or die ref($self),
 		    " no '$restart' in $pfresolved->{logfile}",
 		    " after $timeout seconds";

--- a/regress/args-dnssec-required.pl
+++ b/regress/args-dnssec-required.pl
@@ -36,7 +36,7 @@ our %args = (
 		my $pfresolved = $self->{pfresolved};
 
 		my $restart = qr/starting new resolve request/;
-		my $timeout = 5;
+		my $timeout = 15;
 		$pfresolved->loggrep($restart, $timeout) or die ref($self),
 		    " no '$restart' in $pfresolved->{logfile}",
 		    " after $timeout seconds";

--- a/regress/args-tls-badca.pl
+++ b/regress/args-tls-badca.pl
@@ -43,7 +43,7 @@ our %args = (
 	    my $self = shift;
 	    my $pfresolved = $self->{pfresolved};
 	    my $failed = qr/query for .* failed/;
-	    my $timeout = 5;
+	    my $timeout = 15;
 	    $pfresolved->loggrep($failed, $timeout)
 		or die ref($self), " no '$failed' in $pfresolved->{logfile}",
 		    " after $timeout seconds";

--- a/regress/args-tls-badhost.pl
+++ b/regress/args-tls-badhost.pl
@@ -43,7 +43,7 @@ our %args = (
 	    my $self = shift;
 	    my $pfresolved = $self->{pfresolved};
 	    my $failed = qr/query for .* failed/;
-	    my $timeout = 5;
+	    my $timeout = 15;
 	    $pfresolved->loggrep($failed, $timeout)
 		or die ref($self), " no '$failed' in $pfresolved->{logfile}",
 		    " after $timeout seconds";


### PR DESCRIPTION
Pfctl log contains "Pfctl no '(?^:updated addresses for pf table .*: added: 1,)' in pfresolved.log after 5 seconds for 4 times at Pfctl.pm line 48.".  Pfresolved log starts resolving "parent_send_resolve_request: sending resolve request for foobar.regress. (AAAA) to forwarder", but contains no answer.  Maybe the test is not patient enough.