### PR TITLE
Update CI action to version 0.21.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: OpenBSD Virtual Machine
-        uses: cross-platform-actions/action@v0.21.0
+        uses: cross-platform-actions/action@v0.21.1
         with:
           operating_system: openbsd
           version: '7.4'


### PR DESCRIPTION
The update added retry logic to the disk ejection and should hopefully fix the frequent action fails.