### PR TITLE
Add support for negated addresses

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for pfresolved pf table DNS update daemon
 
 1.01
+  * Add support for negated addresses.
 
 1.00 2023-11-24
   * Initial public release.

--- a/pfresolved.conf.5
+++ b/pfresolved.conf.5
@@ -86,9 +86,12 @@ it will be created by
 A list of hostnames that should be resolved by
 .Xr pfresolved 8
 for the specified table.
-The list can also contain IP addresses.
+The list can also contain IP addresses and networks.
 These will be directly added to the table when the configuration
 file is loaded.
+IP addresses can also be negated by prefixing them with the
+.Cm !\&
+operator.
 Entries in the list may be separated by comma or newline.
 .El
 .Sh EXAMPLES
@@ -99,6 +102,7 @@ myTable2 {
 	example.net
 	example.org
 	198.51.100.0
+	! 198.51.100.1
 	include "/list/with/hosts"
 }
 .Ed

--- a/pfresolved.h
+++ b/pfresolved.h
@@ -181,6 +181,7 @@ struct pfresolved_address {
 struct pfresolved_table_entry {
 	struct pfresolved_address		 pfte_addr;
 	int					 pfte_static;
+	int					 pfte_negate;
 	int					 pfte_refcount;
 	RB_ENTRY(pfresolved_table_entry)	 pfte_node;
 };

--- a/pftable.c
+++ b/pftable.c
@@ -51,6 +51,7 @@ pftable_set_addresses(struct pfresolved *env, struct pfresolved_table *table)
 			buffer[count].pfra_ip6addr = entry->pfte_addr.pfa_addr.in6;
 		}
 		buffer[count].pfra_net = entry->pfte_addr.pfa_prefixlen;
+		buffer[count].pfra_not = entry->pfte_negate;
 		count++;
 	}
 

--- a/regress/Proc.pm
+++ b/regress/Proc.pm
@@ -146,9 +146,11 @@ sub loggrep {
 	my $end;
 	$end = time() + $timeout if $timeout;
 
+	my $expected_status = $self->{expected_status} || 0;
+
 	do {
 		my($kid, $status, $code) = $self->wait(WNOHANG);
-		if ($kid > 0 && $status != 0) {
+		if ($kid > 0 && $status != $expected_status << 8) {
 			# child terminated with failure
 			die ref($self), " child status: $status $code";
 		}

--- a/regress/args-negated-address.pl
+++ b/regress/args-negated-address.pl
@@ -1,0 +1,44 @@
+# Create zone file with A and AAAA records in zone regress.
+# Start nsd with zone file listening on 127.0.0.1.
+# Write hosts of regress zone into pfresolved config.
+# Write negated addresses for hosts in regress zone into pfresolved config.
+# Start pfresolved with nsd as resolver.
+# Wait until pfresolved creates table regress-pfresolved.
+# Read IP addresses from pf table with pfctl.
+# Check that pfresolved resolved IPv4 and IPv6 addresses.
+# Check that pf table only contains the negated IPv4 and IPv6 addresses.
+
+use strict;
+use warnings;
+use Socket;
+
+our %args = (
+    nsd => {
+        record_list => [
+            "foo        IN      A       192.0.2.1",
+            "foo        IN      AAAA    2001:DB8::1",
+        ],
+    },
+    pfresolved => {
+        address_list => [
+            "foo.regress.",
+            "! 192.0.2.1",
+            "! 2001:DB8::1",
+        ],
+        loggrep => {
+            qr{added: 192.0.2.1/32,} => 1,
+            qr{added: 2001:db8::1/128,} => 1,
+        },
+    },
+    pfctl => {
+        updated => [2, 0],
+        loggrep => {
+            qr/^  !192.0.2.1$/ => 1,
+            qr/^   192.0.2.1$/ => 0,
+            qr/^  !2001:db8::1$/ => 1,
+            qr/^   2001:db8::1$/ => 0,
+        },
+    },
+);
+
+1;

--- a/regress/args-negated-network.pl
+++ b/regress/args-negated-network.pl
@@ -1,0 +1,22 @@
+# Write negated network into pfresolved config.
+# Start pfresolved.
+# Check that configuration parsing fails.
+
+use strict;
+use warnings;
+use Socket;
+
+our %args = (
+    pfresolved => {
+        address_list => [
+            "! 192.0.2.1/24",
+        ],
+        loggrep => {
+            qr{negation is not allowed for networks} => 1,
+        },
+        expected_status => 1,
+        down => "parent: parsing configuration failed",
+    },
+);
+
+1;

--- a/regress/args-normal-and-negated-address.pl
+++ b/regress/args-normal-and-negated-address.pl
@@ -1,0 +1,23 @@
+# Write the same address in normal and negated form into pfresolved config.
+# Start pfresolved.
+# Check that configuration parsing fails.
+
+use strict;
+use warnings;
+use Socket;
+
+our %args = (
+    pfresolved => {
+        address_list => [
+            "192.0.2.1",
+            "! 192.0.2.1",
+        ],
+        loggrep => {
+            qr{the same address cannot be specified in normal and negated form} => 1,
+        },
+        expected_status => 1,
+        down => "parent: parsing configuration failed",
+    },
+);
+
+1;


### PR DESCRIPTION
Static addresses can now be negated by prefixing them with the '!'
operator. Negated addresses will be loaded into the configured pf tables
immediately when pfresolved starts and will prevent the pf tables from
matching these addresses.

If a host resolves to such an address it will just reference the negated
address internally, preventing the resolved address from being added to
the pf table in the non-negated form.

Also add tests for this feature:
- Test that negated addresses are added into pf tables and that hosts
resolving to these addresses won't have their addresses added to the
table.
- Test that networks cannot be negated.
- Test that the same address cannot be specified in normal and negated
form.