### PR TITLE
Limit "wpath cpath" to hints file with unveil(2), drop if not used

### DIFF
--- a/pfresolved.c
+++ b/pfresolved.c
@@ -327,8 +327,17 @@ parent_configure(struct pfresolved *env)
 		fatal("opening pf device failed");
 	}
 
-	if (pledge("stdio pf rpath wpath cpath", NULL) == -1)
-		fatal("%s: pledge", __func__);
+	if (env->sc_hints_file) {
+		if (unveil(env->sc_hints_file, "wc") == -1)
+			fatal("%s: unveil %s", __func__, env->sc_hints_file);
+		if (unveil("/", "r") == -1)
+			fatal("%s: unveil /", __func__);
+		if (pledge("stdio pf rpath wpath cpath", NULL) == -1)
+			fatal("%s: pledge", __func__);
+	} else {
+		if (pledge("stdio pf rpath", NULL) == -1)
+			fatal("%s: pledge", __func__);
+	}
 
 	if (parent_init_pftables(env) == -1)
 		fatalx("%s: failed to init pf tables", __func__);

--- a/pfresolved.conf.5
+++ b/pfresolved.conf.5
@@ -81,7 +81,7 @@ table that should be updated with the resolve results of the specified
 If the table does not yet exist in
 .Xr pf 4
 it will be created by
-.Xr pfresolved 8
+.Xr pfresolved 8 .
 .It Ic address_list
 A list of hostnames that should be resolved by
 .Xr pfresolved 8


### PR DESCRIPTION
[-h hints_file] is the only reason pfresolved(8) would create and write
files (after opening pf(4) read/write).

If used, ensure that only the hints file, which remains constant across
reloads, can be created/written while all other filesystem access
(certificates, arbitrary pfresolved.conf(5) includes) are read-only.

If unused, drop write-access entirely.