### PR TITLE
Add control socket and implement pfresolvectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
+SUBDIR+=pfresolvectl
+
 PROG=		pfresolved
 SRCS=		pfresolved.c
-SRCS+=		forwarder.c log.c pftable.c proc.c timer.c util.c
+SRCS+=		forwarder.c log.c pftable.c proc.c timer.c util.c control.c
 SRCS+=		parse.y
 MAN=		pfresolved.8 pfresolved.conf.5
 BINDIR?=	/usr/local/sbin
@@ -21,6 +23,7 @@ LDFLAGS+=	-L/usr/local/lib
 VERSION=	1.02
 CLEANFILES=	pfresolved-${VERSION}.tar.gz*
 REGRESSFILES!=	make -C ${.CURDIR}/regress -V PERLS -V ARGS
+CTLFILES!=	make -C ${.CURDIR}/pfresolvectl -V CTLFILES
 
 .PHONY: dist pfresolved-${VERSION}.tar.gz
 dist: pfresolved-${VERSION}.tar.gz
@@ -36,6 +39,10 @@ pfresolved-${VERSION}.tar.gz:
 	mkdir pfresolved-${VERSION}/regress
 .for f in Makefile ${REGRESSFILES}
 	cp ${.CURDIR}/regress/$f pfresolved-${VERSION}/regress/
+.endfor
+	mkdir pfresolved-${VERSION}/pfresolvectl
+.for f in ${CTLFILES}
+	cp ${.CURDIR}/pfresolvectl/$f pfresolved-${VERSION}/pfresolvectl/
 .endfor
 	tar -czvf $@ pfresolved-${VERSION}
 	rm -rf pfresolved-${VERSION}

--- a/control.c
+++ b/control.c
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2024 genua GmbH
+ * Copyright (c) 2010-2013 Reyk Floeter <reyk@openbsd.org>
+ * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/queue.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <errno.h>
+#include <event.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "pfresolved.h"
+
+#define CONTROL_BACKLOG 5
+
+struct ctl_connlist ctl_conns = TAILQ_HEAD_INITIALIZER(ctl_conns);
+uint32_t ctl_peerid;
+
+void	 control_accept(int, short, void *);
+struct ctl_conn
+	*control_connbyfd(int);
+void	 control_close(int, struct control_sock *);
+void	 control_dispatch_imsg(int, short, void *);
+void	 control_imsg_forward(struct imsg *);
+void	 control_imsg_forward_peerid(struct imsg *);
+void	 control_run(struct privsep *, struct privsep_proc *, void *);
+
+static struct privsep_proc procs[] = {
+	{ "parent", PROC_PARENT, NULL }
+};
+
+void
+control(struct privsep *ps, struct privsep_proc *p)
+{
+	proc_run(ps, p, procs, nitems(procs), control_run, NULL);
+}
+
+void
+control_run(struct privsep *ps, struct privsep_proc *p, void *arg)
+{
+	if (pledge("stdio unix recvfd", NULL) == -1)
+		fatal("%s: pledge", __func__);
+}
+
+int
+control_init(struct privsep *ps, struct control_sock *cs)
+{
+	struct pfresolved       *env = pfresolved_env;
+	struct sockaddr_un       s_un;
+	int                      fd;
+	mode_t                   old_umask, mode;
+
+	if (cs->cs_name == NULL)
+		return (0);
+
+	if ((fd = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0)) == -1) {
+		log_warn("%s: socket", __func__);
+		return (-1);
+	}
+
+	s_un.sun_family = AF_UNIX;
+	if (strlcpy(s_un.sun_path, cs->cs_name,
+	    sizeof(s_un.sun_path)) >= sizeof(s_un.sun_path)) {
+		log_warn("%s: %s name too long", __func__, cs->cs_name);
+		close(fd);
+		return (-1);
+	}
+
+	if (unlink(cs->cs_name) == -1) {
+		if (errno != ENOENT) {
+			log_warn("%s: unlink %s", __func__, cs->cs_name);
+			close(fd);
+			return (-1);
+		}
+	}
+
+	if (cs->cs_restricted) {
+		old_umask = umask(S_IXUSR|S_IXGRP|S_IXOTH);
+		mode = S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH;
+	} else {
+		old_umask = umask(S_IXUSR|S_IXGRP|S_IWOTH|S_IROTH|S_IXOTH);
+		mode = S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP;
+	}
+
+	if (bind(fd, (struct sockaddr *)&s_un, sizeof(s_un)) == -1) {
+		log_warn("%s: bind: %s", __func__, cs->cs_name);
+		close(fd);
+		(void)umask(old_umask);
+		return (-1);
+	}
+	(void)umask(old_umask);
+
+	if (chmod(cs->cs_name, mode) == -1) {
+		log_warn("%s: chmod", __func__);
+		close(fd);
+		(void)unlink(cs->cs_name);
+		return (-1);
+	}
+
+	cs->cs_fd = fd;
+	cs->cs_env = env;
+
+	return (0);
+}
+
+int
+control_listen(struct control_sock *cs)
+{
+	if (cs->cs_name == NULL)
+		return (0);
+
+	if (listen(cs->cs_fd, CONTROL_BACKLOG) == -1) {
+		log_warn("%s: listen", __func__);
+		return (-1);
+	}
+
+	event_set(&cs->cs_ev, cs->cs_fd, EV_READ, control_accept, cs);
+	event_add(&cs->cs_ev, NULL);
+	evtimer_set(&cs->cs_evt, control_accept, cs);
+
+	return (0);
+}
+
+void
+control_accept(int listenfd, short event, void *arg)
+{
+	struct control_sock	*cs = arg;
+	int			 connfd;
+	socklen_t		 len;
+	struct sockaddr_un	 s_un;
+	struct ctl_conn		*c;
+	struct ctl_conn		*other;
+
+	event_add(&cs->cs_ev, NULL);
+	if ((event & EV_TIMEOUT))
+		return;
+
+	len = sizeof(s_un);
+	if ((connfd = accept4(listenfd,
+	    (struct sockaddr *)&s_un, &len, SOCK_NONBLOCK)) == -1) {
+		/*
+		 * Pause accept if we are out of file descriptors, or
+		 * libevent will haunt us here too.
+		 */
+		if (errno == ENFILE || errno == EMFILE) {
+			struct timeval evtpause = { 1, 0 };
+
+			event_del(&cs->cs_ev);
+			evtimer_add(&cs->cs_evt, &evtpause);
+		} else if (errno != EWOULDBLOCK && errno != EINTR &&
+		    errno != ECONNABORTED)
+			log_warn("%s: accept", __func__);
+		return;
+	}
+
+	if ((c = calloc(1, sizeof(struct ctl_conn))) == NULL) {
+		log_warn("%s: calloc", __func__);
+		close(connfd);
+		return;
+	}
+
+	imsg_init(&c->iev.ibuf, connfd);
+	c->iev.handler = control_dispatch_imsg;
+	c->iev.events = EV_READ;
+	c->iev.data = cs;
+	event_set(&c->iev.ev, c->iev.ibuf.fd, c->iev.events,
+	    c->iev.handler, c->iev.data);
+	event_add(&c->iev.ev, NULL);
+
+	/* O(n^2), but n is small */
+	c->peerid = ctl_peerid++;
+	TAILQ_FOREACH(other, &ctl_conns, entry) {
+		if (c->peerid == other->peerid)
+			c->peerid = ctl_peerid++;
+	}
+	TAILQ_INSERT_TAIL(&ctl_conns, c, entry);
+}
+
+struct ctl_conn *
+control_connbyfd(int fd)
+{
+	struct ctl_conn *c;
+
+	TAILQ_FOREACH(c, &ctl_conns, entry) {
+		if (c->iev.ibuf.fd == fd)
+			break;
+	}
+
+	return (c);
+}
+
+void
+control_close(int fd, struct control_sock *cs)
+{
+	struct ctl_conn *c;
+
+	if ((c = control_connbyfd(fd)) == NULL) {
+		log_warn("%s: fd %d: not found", __func__, fd);
+		return;
+	}
+
+	msgbuf_clear(&c->iev.ibuf.w);
+	TAILQ_REMOVE(&ctl_conns, c, entry);
+
+	event_del(&c->iev.ev);
+	close(c->iev.ibuf.fd);
+
+	/* Some file descriptors are available again. */
+	if (evtimer_pending(&cs->cs_evt, NULL)) {
+		evtimer_del(&cs->cs_evt);
+		event_add(&cs->cs_ev, NULL);
+	}
+
+	free(c);
+}
+
+void
+control_dispatch_imsg(int fd, short event, void *arg)
+{
+	struct control_sock	*cs = arg;
+	struct pfresolved	*env = pfresolved_env;
+	struct ctl_conn		*c;
+	struct imsg		 imsg;
+	int			 n, v;
+
+	if ((c = control_connbyfd(fd)) == NULL) {
+		log_warn("%s: fd %d: not found", __func__, fd);
+		return;
+	}
+
+	if (event & EV_READ) {
+		if (((n = imsg_read(&c->iev.ibuf)) == -1 && errno != EAGAIN) ||
+		    n == 0) {
+			control_close(fd, cs);
+			return;
+		}
+	}
+	if (event & EV_WRITE) {
+		if (msgbuf_write(&c->iev.ibuf.w) <= 0 && errno != EAGAIN) {
+			control_close(fd, cs);
+			return;
+		}
+	}
+
+	for (;;) {
+		if ((n = imsg_get(&c->iev.ibuf, &imsg)) == -1) {
+			control_close(fd, cs);
+			return;
+		}
+
+		if (n == 0)
+			break;
+
+		control_imsg_forward(&imsg);
+
+		/* record peerid of connection for reply */
+		imsg.hdr.peerid = c->peerid;
+
+		switch (imsg.hdr.type) {
+		case IMSG_CTL_VERBOSE:
+			IMSG_SIZE_CHECK(&imsg, &v);
+
+			memcpy(&v, imsg.data, sizeof(v));
+			log_setverbose(v);
+
+			proc_forward_imsg(&env->sc_ps, &imsg, PROC_PARENT, -1);
+			break;
+		case IMSG_CTL_RELOAD:
+		case IMSG_CTL_HINTS:
+			proc_forward_imsg(&env->sc_ps, &imsg, PROC_PARENT, -1);
+			break;
+		default:
+			log_debug("%s: error handling imsg %d",
+			    __func__, imsg.hdr.type);
+			break;
+		}
+		imsg_free(&imsg);
+	}
+
+	imsg_event_add(&c->iev);
+}
+
+void
+control_imsg_forward(struct imsg *imsg)
+{
+	struct ctl_conn *c;
+
+	TAILQ_FOREACH(c, &ctl_conns, entry) {
+		if (c->flags & CTL_CONN_NOTIFY)
+			imsg_compose_event(&c->iev, imsg->hdr.type,
+			    0, imsg->hdr.pid, -1, imsg->data,
+			    imsg->hdr.len - IMSG_HEADER_SIZE);
+	}
+}
+
+void
+control_imsg_forward_peerid(struct imsg *imsg)
+{
+	struct ctl_conn *c;
+
+	TAILQ_FOREACH(c, &ctl_conns, entry) {
+		if (c->peerid == imsg->hdr.peerid)
+			imsg_compose_event(&c->iev, imsg->hdr.type,
+			    0, imsg->hdr.pid, -1, imsg->data,
+			    imsg->hdr.len - IMSG_HEADER_SIZE);
+	}
+}
+

--- a/forwarder.c
+++ b/forwarder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 genua GmbH
+ * Copyright (c) 2024 genua GmbH
  *
  * Permission to use, copy, modify, and distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -74,7 +74,7 @@ forwarder_run(struct privsep *ps, struct privsep_proc *p, void *arg)
 	struct pfresolved	*env = ps->ps_env;
 	int			 fd;
 
-	if (pledge("stdio dns inet rpath", NULL) == -1)
+	if (pledge("stdio dns inet rpath recvfd", NULL) == -1)
 		fatal("%s: pledge", __func__);
 
 	if ((fd = ub_fd(env->sc_ub_ctx)) == -1)

--- a/pfresolvectl/Makefile
+++ b/pfresolvectl/Makefile
@@ -1,0 +1,21 @@
+PROG=		pfresolvectl
+SRCS=		pfresolvectl.c parser.c
+MAN=		pfresolvectl.8
+BINDIR?=	/usr/local/sbin
+MANDIR?=	/usr/local/man/man
+
+LDADD+=		-lutil
+DPADD+=		${LIBUTIL}
+
+CFLAGS+=	-I${.CURDIR} -I${.CURDIR}/../ -I/usr/local/include
+CFLAGS+=	-Wall
+CFLAGS+=	-Wstrict-prototypes -Wmissing-prototypes
+CFLAGS+=	-Wmissing-declarations
+CFLAGS+=	-Wshadow -Wpointer-arith -Wcast-qual
+CFLAGS+=	-Wsign-compare
+
+LDFLAGS+=	-L/usr/local/lib
+
+CTLFILES:=	${SRCS} ${MAN} parser.h Makefile
+
+.include <bsd.prog.mk>

--- a/pfresolvectl/parser.c
+++ b/pfresolvectl/parser.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2024 genua GmbH
+ * Copyright (c) 2010-2013 Reyk Floeter <reyk@openbsd.org>
+ * Copyright (c) 2004 Esben Norby <norby@openbsd.org>
+ * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "parser.h"
+
+enum token_type {
+	NOTOKEN,
+	ENDTOKEN,
+	KEYWORD,
+	LOGLEVEL
+};
+
+struct token {
+	enum token_type		 type;
+	const char		*keyword;
+	int			 value;
+	const struct token	*next;
+};
+
+static const struct token t_main[];
+static const struct token t_log[];
+
+static const struct token t_main[] = {
+	{ KEYWORD,	"log",		LOG,		t_log },
+	{ KEYWORD,	"reload",	RELOAD,		NULL },
+	{ KEYWORD,	"hints",	HINTS,		NULL },
+	{ ENDTOKEN,	"",		NONE,		NULL }
+};
+
+static const struct token t_log[] = {
+	{ LOGLEVEL,	"warn",     	0,	        NULL },
+	{ LOGLEVEL,	"notice",     	1,	        NULL },
+	{ LOGLEVEL,	"info",     	2,	        NULL },
+	{ LOGLEVEL,	"debug",     	3,	        NULL },
+	{ ENDTOKEN,	"",		NONE,		NULL }
+};
+
+static struct parse_result	 res;
+
+const struct token		*match_token(char *, const struct token []);
+void				 show_valid_args(const struct token []);
+
+struct parse_result *
+parse(int argc, char *argv[])
+{
+	const struct token	*table = t_main;
+	const struct token	*match;
+
+	bzero(&res, sizeof(res));
+
+	while (argc >= 0) {
+		if ((match = match_token(argv[0], table)) == NULL) {
+			fprintf(stderr, "valid commands/args:\n");
+			show_valid_args(table);
+			return (NULL);
+		}
+
+		argc--;
+		argv++;
+
+		if (match->type == NOTOKEN || match->next == NULL)
+			break;
+
+		table = match->next;
+	}
+
+	if (argc > 0) {
+		fprintf(stderr, "superfluous argument: %s\n", argv[0]);
+		return (NULL);
+	}
+
+	return (&res);
+}
+
+const struct token *
+match_token(char *word, const struct token table[])
+{
+	unsigned int		 i, match = 0;
+	const struct token	*t = NULL;
+
+	for (i = 0; table[i].type != ENDTOKEN; i++) {
+		switch (table[i].type) {
+		case NOTOKEN:
+			if (word == NULL || strlen(word) == 0) {
+				match++;
+				t = &table[i];
+			}
+			break;
+		case KEYWORD:
+			if (word != NULL && strncmp(word, table[i].keyword,
+			    strlen(word)) == 0) {
+				match++;
+				t = &table[i];
+				if (t->value)
+					res.action = t->value;
+			}
+			break;
+		case LOGLEVEL:
+			if (word != NULL && strncmp(word, table[i].keyword,
+			    strlen(word)) == 0) {
+				res.value = table[i].value;
+
+				match++;
+				t = &table[i];
+			}
+			break;
+		case ENDTOKEN:
+			break;
+		}
+	}
+
+	if (match != 1) {
+		if (word == NULL)
+			fprintf(stderr, "missing argument:\n");
+		else if (match > 1)
+			fprintf(stderr, "ambiguous argument: %s\n", word);
+		else if (match < 1)
+			fprintf(stderr, "unknown argument: %s\n", word);
+		return (NULL);
+	}
+
+	return (t);
+}
+
+void
+show_valid_args(const struct token table[])
+{
+	int	i;
+
+	for (i = 0; table[i].type != ENDTOKEN; i++) {
+		switch (table[i].type) {
+		case NOTOKEN:
+			fprintf(stderr, "  <cr>\n");
+			break;
+		case KEYWORD:
+			fprintf(stderr, "  %s\n", table[i].keyword);
+			break;
+		case LOGLEVEL:
+			fprintf(stderr, " %s\n", table[i].keyword);
+			break;
+		case ENDTOKEN:
+			break;
+		}
+	}
+}

--- a/pfresolvectl/parser.h
+++ b/pfresolvectl/parser.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 genua GmbH
+ * Copyright (c) 2007-2013 Reyk Floeter <reyk@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#ifndef PFRESOLVECTL_PARSER_H
+#define PFRESOLVECTL_PARSER_H
+
+enum actions {
+	NONE,
+	LOG,
+	RELOAD,
+	HINTS
+};
+
+struct parse_result {
+	enum actions	 action;
+	int              value;
+};
+
+struct parse_result	*parse(int, char *[]);
+
+#endif /* PFRESOLVECTL_PARSER_H */

--- a/pfresolvectl/pfresolvectl.8
+++ b/pfresolvectl/pfresolvectl.8
@@ -1,0 +1,63 @@
+.\"	$OpenBSD$
+.\"
+.\" Copyright (c) 2024 genua GmbH <bluhm@genua.de>
+.\"
+.\" Permission to use, copy, modify, and distribute this software for any
+.\" purpose with or without fee is hereby granted, provided that the above
+.\" copyright notice and this permission notice appear in all copies.
+.\"
+.\" THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+.\" WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+.\" ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+.\" WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+.\" ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+.\" OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+.\"
+.Dd $Mdocdate$
+.Dt PFRESOLVECTL 8
+.Os
+.Sh NAME
+.Nm pfresolvectl
+.Nd control the pfresolved daemon
+.Sh SYNOPSIS
+.Nm
+.Op Fl s Ar socket
+.Ar command
+.Op Ar arg ...
+.Sh DESCRIPTION
+The
+.Nm
+program can be used to control the
+.Xr pfresolved 8
+daemon.
+.Pp
+The options are as follows:
+.Bl -tag -width Ds
+.It Fl s Ar socket
+The control socket used to communicate with
+.Xr pfresolved 8 .
+The default is
+.Pa /var/run/pfresolved.sock .
+.El
+.Sh PFRESOLVED CONTROL COMMANDS
+The following commands are available to control
+.Xr pfresolved 8 :
+.Bl -tag -width Ds
+.It Cm log Ar level
+Set the loglevel to the specified value.
+Possible levels are:
+.Cm warn ,
+.Cm notice ,
+.Cm info ,
+and
+.Cm debug .
+.It Cm reload
+Reload the configuration from the current configuration file.
+.It Cm hints
+Write the latest resolve results into the configured hints file.
+.El
+.Sh SEE ALSO
+.Xr pfresolved 8
+.Sh AUTHORS
+.An Carsten Beckmann

--- a/pfresolvectl/pfresolvectl.c
+++ b/pfresolvectl/pfresolvectl.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2024 genua GmbH
+ * Copyright (c) 2007-2013 Reyk Floeter <reyk@openbsd.org>
+ * Copyright (c) 2005 Claudio Jeker <claudio@openbsd.org>
+ * Copyright (c) 2004, 2005 Esben Norby <norby@openbsd.org>
+ * Copyright (c) 2003 Henning Brauer <henning@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <strings.h>
+#include <string.h>
+#include <err.h>
+#include <errno.h>
+
+#include "pfresolved.h"
+#include "parser.h"
+
+__dead void	usage(void);
+
+__dead void
+usage(void)
+{
+	extern char *__progname;
+
+	fprintf(stderr, "usage: %s [-s socket] command [arg ...]\n", __progname);
+
+	exit(1);
+}
+
+int
+main(int argc, char **argv)
+{
+	struct sockaddr_un	 s_un;
+	struct parse_result	*res;
+	struct imsgbuf		*ibuf;
+	struct imsg		 imsg;
+	int             	 c;
+	int			 ctl_sock;
+	int			 done = 1;
+	int			 n;
+	const char      	*sock = PFRESOLVED_SOCKET;
+
+	while ((c = getopt(argc, argv, "s:")) != -1) {
+		switch (c) {
+		case 's':
+			sock = optarg;
+			break;
+		default:
+			usage();
+		}
+	}
+
+	argc -= optind;
+	argv += optind;
+
+	if ((res = parse(argc, argv)) == NULL)
+		exit(1);
+
+	if ((ctl_sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+		err(1, "%s: socket", __func__);
+
+	bzero(&s_un, sizeof(s_un));
+	s_un.sun_family = AF_UNIX;
+	if (strlcpy(s_un.sun_path, sock,
+	    sizeof(s_un.sun_path)) >= sizeof(s_un.sun_path))
+		err(1, "%s: %s name too long", __func__, sock);
+
+	if (connect(ctl_sock, (struct sockaddr *)&s_un, sizeof(s_un)) == -1)
+		err(1, "%s: connect", __func__);
+
+	if (pledge("stdio", NULL) == -1)
+		err(1, "%s: pledge", __func__);
+
+	if ((ibuf = calloc(1, sizeof(*ibuf))) == NULL)
+		err(1, "%s: calloc", __func__);
+
+	imsg_init(ibuf, ctl_sock);
+
+	switch (res->action) {
+	case NONE:
+		usage();
+		/* NOTREACHED */
+		break;
+	case LOG:
+		imsg_compose(ibuf, IMSG_CTL_VERBOSE, 0, 0, -1, &res->value,
+		    sizeof(res->value));
+		printf("loglevel request sent.\n");
+		break;
+	case RELOAD:
+		imsg_compose(ibuf, IMSG_CTL_RELOAD, 0, 0, -1, NULL, 0);
+		printf("reload request sent.\n");
+		break;
+	case HINTS:
+		imsg_compose(ibuf, IMSG_CTL_HINTS, 0, 0, -1, NULL, 0);
+		printf("hints file request sent.\n");
+		break;
+	}
+
+	while (ibuf->w.queued) {
+		if (msgbuf_write(&ibuf->w) <= 0 && errno != EAGAIN)
+			err(1, "%s: msgbuf_write", __func__);
+	}
+
+	while (!done) {
+		if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
+			errx(1, "%s: imsg_read error", __func__);
+		if (n == 0)
+			errx(1, "%s: pipe closed", __func__);
+
+		while (!done) {
+			if ((n = imsg_get(ibuf, &imsg)) == -1)
+				errx(1, "%s: imsg_get error", __func__);
+			if (n == 0)
+				break;
+
+			switch (res->action) {
+			default:
+				break;
+			}
+
+			imsg_free(&imsg);
+		}
+	}
+
+	close(ctl_sock);
+	free(ibuf);
+
+	return (0);
+}

--- a/pfresolved.8
+++ b/pfresolved.8
@@ -1,6 +1,6 @@
 .\"	$OpenBSD$
 .\"
-.\" Copyright (c) 2023 genua GmbH <bluhm@genua.de>
+.\" Copyright (c) 2024 genua GmbH <bluhm@genua.de>
 .\"
 .\" Permission to use, copy, modify, and distribute this software for any
 .\" purpose with or without fee is hereby granted, provided that the above
@@ -32,6 +32,7 @@
 .Op Fl m Ar seconds
 .Op Fl r Ar resolver
 .Op Fl S Ar dnssec_level
+.Op Fl s Ar socket
 .Sh DESCRIPTION
 .Nm pfresolved
 is a daemon which resolves hostnames using DNS and updates
@@ -119,6 +120,10 @@ Results from zones that are not signed with DNSSEC are still allowed.
 DNSSEC is enabled and required for every zone.
 Unsigned query results will be discarded.
 .El
+.It Fl s Ar socket
+The control socket to use.
+Default is
+.Pa /var/run/pfresolved.sock .
 .It Fl T
 Enable DNS-over-TLS.
 The system certificates will be automatically included and used for

--- a/proc.c
+++ b/proc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 genua GmbH
+ * Copyright (c) 2024 genua GmbH
  * Copyright (c) 2010 - 2016 Reyk Floeter <reyk@openbsd.org>
  * Copyright (c) 2008 Pierre-Yves Ritschard <pyr@openbsd.org>
  *
@@ -649,8 +649,6 @@ proc_run(struct privsep *ps, struct privsep_proc *p,
 {
 	struct passwd		*pw;
 	const char		*root;
-        /* XXX: no control socket for now */
-	/*struct control_sock	*rcs;*/
 #ifdef GENUOS
 	struct			 sigaction sa;
 #endif
@@ -660,14 +658,10 @@ proc_run(struct privsep *ps, struct privsep_proc *p,
 	/* Set the process group of the current process */
 	setpgid(0, 0);
 
-        /* XXX: no control socket for now */
-	/*if (p->p_id == PROC_CONTROL && ps->ps_instance == 0) {
+	if (p->p_id == PROC_CONTROL && ps->ps_instance == 0) {
 		if (control_init(ps, &ps->ps_csock) == -1)
 			fatalx("%s: control_init", __func__);
-		TAILQ_FOREACH(rcs, &ps->ps_rcsocks, cs_entry)
-			if (control_init(ps, rcs) == -1)
-				fatalx("%s: control_init", __func__);
-	}*/
+	}
 
 	/* Use non-standard user */
 	if (p->p_pw != NULL)
@@ -724,14 +718,10 @@ proc_run(struct privsep *ps, struct privsep_proc *p,
 
 	proc_setup(ps, procs, nproc);
 	proc_accept(ps, PROC_PARENT_SOCK_FILENO, PROC_PARENT, 0);
-        /* XXX: no control socket for now */
-	/*if (p->p_id == PROC_CONTROL && ps->ps_instance == 0) {
+	if (p->p_id == PROC_CONTROL && ps->ps_instance == 0) {
 		if (control_listen(&ps->ps_csock) == -1)
 			fatalx("%s: control_listen", __func__);
-		TAILQ_FOREACH(rcs, &ps->ps_rcsocks, cs_entry)
-			if (control_listen(rcs) == -1)
-				fatalx("%s: control_listen", __func__);
-	}*/
+	}
 
 #if DEBUG
 	log_debug("%s: %s %d/%d, pid %d", __func__, p->p_title,


### PR DESCRIPTION
Adds a control process and control socket to pfresolved, allowing it to be controlled from other programs. Also adds a new program called 'pfresolvectl' that utilizes this socket. It can be used to change the log level of pfresolved, reload the current configuration, or trigger pfresolved to write the hints file if configured.

The implementation is based on 'control.c' from iked(8) and on ikectl(8).