### PR TITLE
Adjust pfresolved to the new imsg world.

### DIFF
--- a/control.c
+++ b/control.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 genua GmbH
+ * Copyright (c) 2024-2025 genua GmbH
  * Copyright (c) 2010-2013 Reyk Floeter <reyk@openbsd.org>
  * Copyright (c) 2003, 2004 Henning Brauer <henning@openbsd.org>
  *
@@ -177,7 +177,11 @@ control_accept(int listenfd, short event, void *arg)
 		return;
 	}
 
-	imsg_init(&c->iev.ibuf, connfd);
+	if (imsgbuf_init(&c->iev.ibuf, connfd) == -1) {
+		log_warn("%s: imsgbuf_init", __func__);
+		close(connfd);
+		return;
+	}
 	c->iev.handler = control_dispatch_imsg;
 	c->iev.events = EV_READ;
 	c->iev.data = cs;
@@ -217,7 +221,7 @@ control_close(int fd, struct control_sock *cs)
 		return;
 	}
 
-	msgbuf_clear(&c->iev.ibuf.w);
+	imsgbuf_clear(&c->iev.ibuf);
 	TAILQ_REMOVE(&ctl_conns, c, entry);
 
 	event_del(&c->iev.ev);
@@ -247,14 +251,13 @@ control_dispatch_imsg(int fd, short event, void *arg)
 	}
 
 	if (event & EV_READ) {
-		if (((n = imsg_read(&c->iev.ibuf)) == -1 && errno != EAGAIN) ||
-		    n == 0) {
+		if ((n = imsgbuf_read(&c->iev.ibuf)) == -1 || n == 0) {
 			control_close(fd, cs);
 			return;
 		}
 	}
 	if (event & EV_WRITE) {
-		if (msgbuf_write(&c->iev.ibuf.w) <= 0 && errno != EAGAIN) {
+		if (imsgbuf_write(&c->iev.ibuf) == -1) {
 			control_close(fd, cs);
 			return;
 		}

--- a/pfresolvectl/pfresolvectl.c
+++ b/pfresolvectl/pfresolvectl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 genua GmbH
+ * Copyright (c) 2024-2025 genua GmbH
  * Copyright (c) 2007-2013 Reyk Floeter <reyk@openbsd.org>
  * Copyright (c) 2005 Claudio Jeker <claudio@openbsd.org>
  * Copyright (c) 2004, 2005 Esben Norby <norby@openbsd.org>
@@ -91,7 +91,8 @@ main(int argc, char **argv)
 	if ((ibuf = calloc(1, sizeof(*ibuf))) == NULL)
 		err(1, "%s: calloc", __func__);
 
-	imsg_init(ibuf, ctl_sock);
+	if (imsgbuf_init(ibuf, ctl_sock) == -1)
+		err(1, "%s: imsgbuf_init", __func__);
 
 	switch (res->action) {
 	case NONE:
@@ -113,14 +114,14 @@ main(int argc, char **argv)
 		break;
 	}
 
-	while (ibuf->w.queued) {
-		if (msgbuf_write(&ibuf->w) <= 0 && errno != EAGAIN)
-			err(1, "%s: msgbuf_write", __func__);
+	while (imsgbuf_queuelen(ibuf)) {
+		if (imsgbuf_write(ibuf) == -1)
+			err(1, "%s: imsgbuf_write", __func__);
 	}
 
 	while (!done) {
-		if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
-			errx(1, "%s: imsg_read error", __func__);
+		if ((n = imsgbuf_read(ibuf)) == -1)
+			errx(1, "%s: imsgbuf_read error", __func__);
 		if (n == 0)
 			errx(1, "%s: pipe closed", __func__);
 

--- a/proc.c
+++ b/proc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 genua GmbH
+ * Copyright (c) 2024-2025 genua GmbH
  * Copyright (c) 2010 - 2016 Reyk Floeter <reyk@openbsd.org>
  * Copyright (c) 2008 Pierre-Yves Ritschard <pyr@openbsd.org>
  *
@@ -181,7 +181,10 @@ proc_connect(struct privsep *ps)
 
 		for (inst = 0; inst < ps->ps_instances[dst]; inst++) {
 			iev = &ps->ps_ievs[dst][inst];
-			imsg_init(&iev->ibuf, ps->ps_pp->pp_pipes[dst][inst]);
+			if (imsgbuf_init(&iev->ibuf,
+			    ps->ps_pp->pp_pipes[dst][inst]) == -1)
+				fatal("%s: imsgbuf_init", __func__);
+			imsgbuf_allow_fdpass(&iev->ibuf);
 			event_set(&iev->ev, iev->ibuf.fd, iev->events,
 			    iev->handler, iev->data);
 			event_add(&iev->ev, NULL);
@@ -289,7 +292,9 @@ proc_accept(struct privsep *ps, int fd, enum privsep_procid dst,
 		pp->pp_pipes[dst][n] = fd;
 
 	iev = &ps->ps_ievs[dst][n];
-	imsg_init(&iev->ibuf, fd);
+	if (imsgbuf_init(&iev->ibuf, fd) == -1)
+		fatal("%s: imsgbuf_init", __func__);
+	imsgbuf_allow_fdpass(&iev->ibuf);
 	event_set(&iev->ev, iev->ibuf.fd, iev->events, iev->handler, iev->data);
 	event_add(&iev->ev, NULL);
 }
@@ -489,7 +494,7 @@ proc_close(struct privsep *ps)
 
 			/* Cancel the fd, close and invalidate the fd */
 			event_del(&(ps->ps_ievs[dst][n].ev));
-			imsg_clear(&(ps->ps_ievs[dst][n].ibuf));
+			imsgbuf_clear(&(ps->ps_ievs[dst][n].ibuf));
 			close(pp->pp_pipes[dst][n]);
 			pp->pp_pipes[dst][n] = -1;
 		}
@@ -753,8 +758,8 @@ proc_dispatch(int fd, short event, void *arg)
 	ibuf = &iev->ibuf;
 
 	if (event & EV_READ) {
-		if ((n = imsg_read(ibuf)) == -1 && errno != EAGAIN)
-			fatal("%s: imsg_read", __func__);
+		if ((n = imsgbuf_read(ibuf)) == -1)
+			fatal("%s: imsgbuf_read", __func__);
 		if (n == 0) {
 			/* this pipe is dead, so remove the event handler */
 			event_del(&iev->ev);
@@ -764,13 +769,14 @@ proc_dispatch(int fd, short event, void *arg)
 	}
 
 	if (event & EV_WRITE) {
-		if ((n = msgbuf_write(&ibuf->w)) == -1 && errno != EAGAIN)
-			fatal("%s: msgbuf_write", __func__);
-		if (n == 0) {
-			/* this pipe is dead, so remove the event handler */
-			event_del(&iev->ev);
-			event_loopexit(NULL);
-			return;
+		if ((n = imsgbuf_write(ibuf)) == -1) {
+			if (errno == EPIPE) {
+				/* this pipe is dead */
+				event_del(&iev->ev);
+				event_loopexit(NULL);
+				return;
+			}
+			fatal("%s: imsgbuf_write", __func__);
 		}
 	}
 
@@ -807,7 +813,7 @@ proc_dispatch(int fd, short event, void *arg)
 		case IMSG_CTL_PROCFD:
 			IMSG_SIZE_CHECK(&imsg, &pf);
 			memcpy(&pf, imsg.data, sizeof(pf));
-			proc_accept(ps, imsg.fd, pf.pf_procid,
+			proc_accept(ps, imsg_get_fd(&imsg), pf.pf_procid,
 			    pf.pf_instance);
 			break;
 		default:
@@ -836,12 +842,12 @@ void
 imsg_event_add(struct imsgev *iev)
 {
 	if (iev->handler == NULL) {
-		imsg_flush(&iev->ibuf);
+		imsgbuf_flush(&iev->ibuf);
 		return;
 	}
 
 	iev->events = EV_READ;
-	if (iev->ibuf.w.queued)
+	if (imsgbuf_queuelen(&iev->ibuf) > 0)
 		iev->events |= EV_WRITE;
 
 	event_del(&iev->ev);
@@ -941,7 +947,8 @@ proc_forward_imsg(struct privsep *ps, struct imsg *imsg,
     enum privsep_procid id, int n)
 {
 	return (proc_compose_imsg(ps, id, n, imsg->hdr.type,
-	    imsg->hdr.peerid, imsg->fd, imsg->data, IMSG_DATA_SIZE(imsg)));
+	    imsg->hdr.peerid, imsg_get_fd(imsg), imsg->data,
+	    IMSG_DATA_SIZE(imsg)));
 }
 
 struct imsgbuf *
@@ -974,7 +981,7 @@ proc_flush_imsg(struct privsep *ps, enum privsep_procid id, int n)
 		if ((ibuf = proc_ibuf(ps, id, n)) == NULL)
 			return (-1);
 		do {
-			ret = imsg_flush(ibuf);
+			ret = imsgbuf_flush(ibuf);
 		} while (ret == -1 && errno == EAGAIN);
 		if (ret == -1)
 			break;


### PR DESCRIPTION
The API of imsg has change in OpenBSD 7.7.  This commit is uptreaming ports/net/pfresolved/patches/patch-proc_c.  Additional changes for the controll socket are necessary.

----------------------------
revision 1.1
date: 2024/11/21 14:30:54;  author: claudio;  state: Exp;  commitid: 9Q5mmIUnSCPamPJj; Adjust pfresolved to the new imsg world.
OK tb@
----------------------------